### PR TITLE
Laravel uses handle() method now instead of fire()

### DIFF
--- a/src/Console/MetricsTableCommand.php
+++ b/src/Console/MetricsTableCommand.php
@@ -51,7 +51,7 @@ class MetricsTableCommand extends Command
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $fullPath = $this->createBaseMigration();
 


### PR DESCRIPTION
This will allow newer versions of Laravel to use this package.